### PR TITLE
Update lab2.rst to reference 'superjump' instead of 'ocp-provisioner'

### DIFF
--- a/docs/class1/module4/lab2.rst
+++ b/docs/class1/module4/lab2.rst
@@ -35,14 +35,14 @@ Lab 4.2 - Deploy the Cafe Application
 Test the Application
 --------------------
 
-Now let's test access to the new web application "*through*"" **Firefox** on **ocp-provisioner**.
+Now let's test access to the new web application "*through*"" **Firefox** on **superjump**.
 
 #. Go back to the Firefox session you opened in a previous task. If you need to open a new session,
    browse back to the **Deployment** tab of your UDF lab session at
-   https://udf.f5.com and connect to **ocp-provisioner** using the **Firefox** access method.
+   https://udf.f5.com and connect to **superjump** using the **Firefox** access method.
 
    .. note:: The web application is not directly accessible from the public Internet.
-      But since the **ocp-provisioner** system is connected to the same internal virtual lab network 
+      But since the **superjump** system is connected to the same internal virtual lab network 
       we can use the **Firefox** access method because it provides *browser-in-a-browser*
       functionality that allows remote browsing to this new private web site.
 


### PR DESCRIPTION
### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).